### PR TITLE
Fix IT translation for question_2.md

### DIFF
--- a/it-IT/quiz1/question_2.md
+++ b/it-IT/quiz1/question_2.md
@@ -4,7 +4,7 @@
 legend: Domanda 2 di 3
 ---
 
-Hai fatto `dire` a Pico {:class="block3looks"} "Ciao!" in un fumetto.
+Hai fatto `dire`{:class="block3looks"} a Pico "Ciao!" in un fumetto.
 
 ```blocks3
 say [Ciao!] for [2] seconds


### PR DESCRIPTION
looks like there's been some mis-formatting so the the styling has been separated from the text, this should fix it.

This is how it looks rendered in the website, 

<img width="585" alt="Screenshot 2024-09-15 at 17 33 23" src="https://github.com/user-attachments/assets/f950bad4-b713-41bb-a10a-b97eec341547">

Sadly, I have no clue how to actually test my change but I think it's correct :) 